### PR TITLE
Sync CI configuration files with templates

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,4 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/spell-check/.codespellrc
 # See: https://github.com/codespell-project/codespell#using-a-config-file
 [codespell]
 # In the event of a false positive, add the problematic word, in all lowercase, to a comma-separated list here:

--- a/.codespellrc
+++ b/.codespellrc
@@ -2,7 +2,7 @@
 [codespell]
 # In the event of a false positive, add the problematic word, in all lowercase, to a comma-separated list here:
 ignore-words-list = ,
-skip = ./.git
+skip = ./.git,./go.mod,./go.sum,./package-lock.json,./poetry.lock,./yarn.lock
 builtin = clear,informal,en-GB_to_en-US
 check-filenames =
 check-hidden =

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,8 +1,8 @@
 # See: https://github.com/codespell-project/codespell#using-a-config-file
 [codespell]
-builtin = clear,informal,en-GB_to_en-US
 # In the event of a false positive, add the problematic word, in all lowercase, to a comma-separated list here:
 ignore-words-list = ,
+skip = ./.git
+builtin = clear,informal,en-GB_to_en-US
 check-filenames =
 check-hidden =
-skip = ./.git

--- a/.ecrc
+++ b/.ecrc
@@ -1,3 +1,6 @@
 {
-  "Exclude": ["^LICENSE\\.txt$"]
+  "Exclude": [
+    "^LICENSE\\.txt$",
+    "^poetry\\.lock$"
+  ]
 }

--- a/.ecrc
+++ b/.ecrc
@@ -1,3 +1,3 @@
 {
-  "Exclude": ["LICENSE.txt"]
+  "Exclude": ["^LICENSE\\.txt$"]
 }

--- a/.editorconfig
+++ b/.editorconfig
@@ -24,7 +24,7 @@ indent_style = space
 indent_size = 2
 indent_style = space
 
-[*.go]
+[*.{go,mod}]
 indent_style = tab
 
 [*.java]
@@ -39,6 +39,10 @@ indent_style = space
 indent_size = unset
 indent_style = space
 
+[*.proto]
+indent_size = 2
+indent_style = space
+
 [*.py]
 indent_size = 4
 indent_style = space
@@ -50,3 +54,6 @@ indent_style = space
 [*.{yaml,yml}]
 indent_size = 2
 indent_style = space
+
+[{.gitconfig,.gitmodules}]
+indent_style = tab

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,4 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/general/.editorconfig
 # See: https://editorconfig.org/
 # The formatting style defined in this file is the official standardized style to be used in all Arduino Tooling
 # projects and should not be modified.

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,6 @@
 # See: https://editorconfig.org/
-# The formatting style defined in this file is the official standardized style to be used in all Arduino projects and
-# should not be modified.
+# The formatting style defined in this file is the official standardized style to be used in all Arduino Tooling
+# projects and should not be modified.
 # Note: indent style for each file type is defined even when it matches the universal config in order to make it clear
 # that this type has an official style.
 

--- a/.github/workflows/check-yaml.yml
+++ b/.github/workflows/check-yaml.yml
@@ -59,11 +59,11 @@ jobs:
             # yamllint's "github" output type produces annotated diffs, but is not useful to humans reading the log.
             format: github
             # The other matrix job is used to set the result, so this job is configured to always pass.
-            fail-command: "true"
+            continue-on-error: true
           - name: Check formatting
             # yamllint's "colored" output type is most suitable for humans reading the log.
             format: colored
-            fail-command: "false"
+            continue-on-error: false
 
     steps:
       - name: Checkout repository
@@ -71,30 +71,8 @@ jobs:
 
       - name: Check YAML
         # yamllint's "colored" output type is useful for humans reading the log.
+        continue-on-error: ${{ matrix.configuration.continue-on-error }}
         run: |
-          find . \
-            -path './.git' -prune -or \
-            \( \
-              \( \
-                -name '.clang-format' -or \
-                -name '.clang-tidy' -or \
-                -name '.gemrc' -or \
-                -name '*.yml' -or \
-                -name '*.mir' -or \
-                -name '*.reek' -or \
-                -name '*.rviz' -or \
-                -name '*.sublime-syntax' -or \
-                -name '*.syntax' -or \
-                -name '*.yaml' -or \
-                -name '*.yaml-tmlanguage' -or \
-                -name '*.yaml.sed' -or \
-                -name '*.yaml.mysql' \
-              \) \
-              -and -type f \
-            \) \
-            -exec \
-              yamllint \
-                --format ${{ matrix.configuration.format }} \
-                '{}' + \
-                || \
-                ${{ matrix.configuration.fail-command }}
+          yamllint \
+            --format ${{ matrix.configuration.format }} \
+            .

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,3 +1,4 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-markdown/.markdownlint.yml
 # See: https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md
 # The code style defined in this file is the official standardized style to be used in all Arduino projects and should
 # not be modified.

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -31,8 +31,7 @@ MD024: false
 MD025:
   level: 1
   front_matter_title: '^\s*"?title"?\s*[:=]'
-MD026:
-  punctuation: ":"
+MD026: false
 MD027: false # Prettier
 MD028: false
 MD029:

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -50,3 +50,24 @@ rules:
       - "false"
       - "on" # Used by GitHub Actions as a workflow key.
     check-keys: true
+
+yaml-files:
+  # Source: https://github.com/ikatyang/linguist-languages/blob/master/data/YAML.json (used by Prettier)
+  - ".clang-format"
+  - ".clang-tidy"
+  - ".gemrc"
+  - ".yamllint"
+  - "glide.lock"
+  - "*.yml"
+  - "*.mir"
+  - "*.reek"
+  - "*.rviz"
+  - "*.sublime-syntax"
+  - "*.syntax"
+  - "*.yaml"
+  - "*.yaml-tmlanguage"
+  - "*.yaml.sed"
+  - "*.yml.mysql"
+
+ignore: |
+  /.git/

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,6 +1,6 @@
 # See: https://yamllint.readthedocs.io/en/stable/configuration.html
-# The code style defined in this file is the official standardized style to be used in all Arduino projects and should
-# not be modified.
+# The code style defined in this file is the official standardized style to be used in all Arduino tooling projects and
+# should not be modified.
 # Note: Rules disabled solely because they are redundant to Prettier are marked with a "Prettier" comment.
 
 rules:

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,3 +1,4 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-yaml/.yamllint.yml
 # See: https://yamllint.readthedocs.io/en/stable/configuration.html
 # The code style defined in this file is the official standardized style to be used in all Arduino tooling projects and
 # should not be modified.


### PR DESCRIPTION
We have assembled a collection of reusable project assets:
https://github.com/arduino/tooling-project-assets
These will be used in the repositories of all Arduino tooling projects.

Some minor improvements and standardizations have been made in the upstream "template" assets, and those are introduced to this repository via this pull request.