### PR TITLE
Exclude published RFCs from automated checks

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -3,7 +3,7 @@
 [codespell]
 # In the event of a false positive, add the problematic word, in all lowercase, to a comma-separated list here:
 ignore-words-list = ,
-skip = ./.git,./go.mod,./go.sum,./package-lock.json,./poetry.lock,./yarn.lock
+skip = ./.git,./go.mod,./go.sum,./package-lock.json,./poetry.lock,./yarn.lock,./RFCs/0002-pluggable-discovery.md,./RFCs/0003-build-profiles.md,./RFCs/0004-pluggable-monitor.md
 builtin = clear,informal,en-GB_to_en-US
 check-filenames =
 check-hidden =

--- a/.ecrc
+++ b/.ecrc
@@ -1,6 +1,9 @@
 {
   "Exclude": [
     "^LICENSE\\.txt$",
-    "^poetry\\.lock$"
+    "^poetry\\.lock$",
+    "^RFCs/0002-pluggable-discovery.md",
+    "^RFCs/0003-build-profiles.md",
+    "^RFCs/0004-pluggable-monitor.md"
   ]
 }

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,0 +1,7 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-markdown/.markdownlintignore
+.licenses/
+__pycache__/
+node_modules/
+/RFCs/0002-pluggable-discovery.md
+/RFCs/0003-build-profiles.md
+/RFCs/0004-pluggable-monitor.md

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,6 @@
+.licenses/
+__pycache__/
+node_modules/
+/RFCs/0002-pluggable-discovery.md
+/RFCs/0003-build-profiles.md
+/RFCs/0004-pluggable-monitor.md


### PR DESCRIPTION
The development and maintenance of the contents of this repository is facilitated by the use of tools, both locally by the contributor, and automatically on relevant changes by [the continuous integration system](https://github.com/arduino/tooling-rfcs/actions).

New issues may be detected by updating to a new version of a tool, or improving its configuration. For example, an update to a new version of [the **codespell** tool](https://github.com/codespell-project/codespell) used for spell checking in this project made a valid detection of a misspelled word in one of the RFCs:

https://github.com/arduino/tooling-rfcs/runs/8087283979?check_suite_focus=true#step:4:17

```text
Error: ./RFCs/0002-pluggable-discovery.md:582: indepentent ==> independent
Codespell found one or more problems
```

In the case where this issue is in a published RFC, it is difficult to resolve. Although a new revision may be created, [standard practice is to not modify published RFCs](https://en.wikipedia.org/wiki/Request_for_Comments#Production_and_versioning). Creation of a new revision would not be appropriate for a minor typo or formatting fix.

For this reason, the best approach will be to configure the tools to ignore the published RFCs.

The exception is [the link check](https://github.com/arduino/tooling-rfcs/blob/8c1a9916c4b0f84c8717f582b6b928d4e138e5e5/.github/workflows/check-markdown.yml#L48), since we may be able to fix broken links to pages controlled by Arduino (e.g., by setting up external redirects).