### PR TITLE
Exclude additional paths in editorconfig-checker configuration

### DIFF
--- a/.ecrc
+++ b/.ecrc
@@ -1,5 +1,9 @@
 {
   "Exclude": [
+    "^\\.git[/\\\\]",
+    "^\\.licenses[/\\\\]",
+    "__pycache__[/\\\\]",
+    "node_modules[/\\\\]",
     "^LICENSE\\.txt$",
     "^poetry\\.lock$",
     "^RFCs/0002-pluggable-discovery.md",


### PR DESCRIPTION
The excellent [**editorconfig-checker**](https://github.com/editorconfig-checker/editorconfig-checker) tool is used to check for compliance with the standardized basic formatting style in the project files.

This check should only be done on the files that are directly developed as part of the project. Any generated or externally maintained files should not be checked, since we don't have control over the formatting of those files.

Previously the tool was checking the generated files in the `.git` folder. This resulted in a spurious failure of the check:

https://github.com/arduino/tooling-rfcs/actions/runs/5517400550/jobs/10059966234

```text
.git/config:
	2: Wrong amount of left-padding spaces(want multiple of 2)
	3: Wrong amount of left-padding spaces(want multiple of 2)
	[4](https://github.com/arduino/tooling-rfcs/actions/runs/5517400550/jobs/10059966234#step:4:5): Wrong amount of left-padding spaces(want multiple of 2)
	[5](https://github.com/arduino/tooling-rfcs/actions/runs/5517400550/jobs/10059966234#step:4:6): Wrong amount of left-padding spaces(want multiple of 2)

[...]
```

The [`.ecrc` configuration file](https://github.com/editorconfig-checker/editorconfig-checker#configuration) is hereby synced with [the standardized upstream "template"](https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-general-formatting/.ecrc), introducing an [exclusion](https://github.com/editorconfig-checker/editorconfig-checker#via-configuration) of the `.git` folder as well as other common locations of generated and externally maintained files.